### PR TITLE
CLOUD-490: support flat formats when writing strings

### DIFF
--- a/common/cmd.go
+++ b/common/cmd.go
@@ -19,6 +19,7 @@ type Options struct {
 	OutputMatchImportFlag  bool
 	OutputMatchPackageFlag bool
 	OutputFlatFlag         bool
+	OutputFormatFlatFlag   bool
 
 	ExcludedFilenameFlag  string
 	SubstringFilenameFlag string

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -4,10 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
-
-	"runtime/debug"
 
 	"github.com/EverlongProject/i18n4go/cmds"
 	"github.com/EverlongProject/i18n4go/common"
@@ -233,6 +232,7 @@ func init() {
 
 	flag.BoolVar(&options.OutputFlatFlag, "output-flat", true, "generated files are created in the specified output directory")
 	flag.BoolVar(&options.OutputMatchPackageFlag, "output-match-package", false, "generated files are created in directory to match the package name")
+	flag.BoolVar(&options.OutputFormatFlatFlag, "output-format-flat", false, "generated files are created in flat file format")
 
 	flag.StringVar(&options.FilenameFlag, "f", "", "the file name for which strings are extracted")
 


### PR DESCRIPTION
Add a command-line option to write strings files in a flat map[string]string (or map[string]obj, for plurals) format, so we can deal with Localise's output directly rather than needing separate translation steps going to/from it.