### PR TITLE
Remove leading hyphen from "help" flag

### DIFF
--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -211,7 +211,7 @@ func init() {
 	flag.StringVar(&options.CommandFlag, "c", "", "the command, one of: extract-strings, create-translations, rewrite-package, verify-strings, merge-strings, checkup, fixup")
 
 	flag.BoolVar(&options.HelpFlag, "h", false, "prints the usage")
-	flag.BoolVar(&options.LongHelpFlag, "-help", false, "prints the usage")
+	flag.BoolVar(&options.LongHelpFlag, "help", false, "prints the usage")
 
 	flag.StringVar(&options.SourceLanguageFlag, "source-language", "en", "the source language of the file, typically also part of the file name, e.g., \"en_US\"")
 	flag.StringVar(&options.LanguagesFlag, "languages", "", "a comma separated list of valid languages with optional territory, e.g., \"en, en_US, fr_FR, es\"")


### PR DESCRIPTION
This is an invalid name for a flag, and Go 1.17 rejects it (see https://github.com/golang/go/issues/41792).