### PR TITLE
BACK-2258: Exclude auto generated code from being inspected for strings extractions

### DIFF
--- a/cmds/extract_strings.go
+++ b/cmds/extract_strings.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 
+	"dmitri.shuralyov.com/go/generated"
 	"github.com/EverlongProject/i18n4go/common"
 )
 
@@ -132,6 +133,12 @@ func (es *extractStrings) Run() error {
 }
 
 func (es *extractStrings) InspectFile(filename string) error {
+	if isGenerated, err := generated.ParseFile(filename); isGenerated {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
 	es.Println("i18n4go: extracting strings from file:", filename)
 	if es.options.DryRunFlag {
 		es.Println("WARNING running in -dry-run mode")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/EverlongProject/i18n4go
 go 1.16
 
 require (
+	dmitri.shuralyov.com/go/generated v0.0.0-20211227232225-c5b6cf572ec5 // indirect
 	github.com/EverlongProject/go-i18n v1.8.1
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dmitri.shuralyov.com/go/generated v0.0.0-20211227232225-c5b6cf572ec5 h1:aVJ7xNKqudwDKOM6ynz6Y/Ii1iIgiB8YgsPU5mKWYa0=
+dmitri.shuralyov.com/go/generated v0.0.0-20211227232225-c5b6cf572ec5/go.mod h1:WG7q7swWsS2f9PYpt5DoEP/EBYWx8We5UoRltn9vJl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/EverlongProject/go-i18n v1.8.1 h1:sjVYzW3zPTyGi9MCTua9zVL12T2QlHKP8kyfqzL9/CU=


### PR DESCRIPTION
For REST api development, we're making use of github.com/deepmap/oapi-codegen to auto generate server stubs from API specs. Strings are being picked up by our patch_strings script in services repo. Exclude auto generated files from being extracted for localization. We can't integrate our localizer for these strings and the callers of auto generated code methods should handle localization of string values if needed. More commonly, these are just errors like `"Header parameter XDRxBanner is required, but not found"` which we should just be logging and not returning back to the client.