### PR TITLE
support a locales: comment directive in extract_strings

### DIFF
--- a/common/cmd.go
+++ b/common/cmd.go
@@ -54,6 +54,9 @@ type StringInfo struct {
 	Offset   int    `json:"offset"`
 	Line     int    `json:"line"`
 	Column   int    `json:"column"`
+
+	// optional, empty means "all locales"
+	Locales []string `json:"locales,omitempty"`
 }
 
 type ExcludedStrings struct {

--- a/test_fixtures/extract_strings/f_option/expected_output/app.go.extracted.json
+++ b/test_fixtures/extract_strings/f_option/expected_output/app.go.extracted.json
@@ -4,7 +4,8 @@
       "value": "Show help",
       "offset": 1332,
       "line": 36,
-      "column": 16
+      "column": 16,
+      "locales": ["fr"]
    },
    {
       "filename": "../../test_fixtures/extract_strings/f_option/input_files/app.go",

--- a/test_fixtures/extract_strings/f_option/input_files/app.go
+++ b/test_fixtures/extract_strings/f_option/input_files/app.go
@@ -39,8 +39,9 @@ var appHelpTemplate = `{{.Title "NAME:"}}
 
 func NewApp(cmdRunner command_runner.Runner, metadatas ...command_metadata.CommandMetadata) (app *cli.App) {
 	helpCommand := cli.Command{
-		Name:        "help",
-		ShortName:   "h",
+		Name:      "help",
+		ShortName: "h",
+		//locales:fr
 		Description: "Show help",
 		Usage:       fmt.Sprintf("%s help [COMMAND]", cf.Name()),
 		Action: func(c *cli.Context) {


### PR DESCRIPTION
We want to support some strings that are only intended to be translated into certain languages. To manage that, add a "//locales:" comment directive, and parse it in the extract_strings command. Anything in a block with this directive will be parsed with a Locales entry in its StringInfo.

This isn't supported in the other commands yet, so it's currently only visible in the .extracted.json file.