### PR TITLE
merge locales if we find the same string multiple times

### DIFF
--- a/cmds/extract_strings_test.go
+++ b/cmds/extract_strings_test.go
@@ -1,0 +1,45 @@
+package cmds
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeLocales(t *testing.T) {
+	tests := []struct {
+		a   []string
+		b   []string
+		exp []string
+	}{
+		{
+			// result should be the union of locales (a disjoint from b)
+			a:   []string{"en"},
+			b:   []string{"fr"},
+			exp: []string{"en", "fr"},
+		},
+		{
+			// result should be the union of locales (a subset of b)
+			a:   []string{"fr"},
+			b:   []string{"en", "fr"},
+			exp: []string{"en", "fr"},
+		},
+		{
+			// if one of the entries has no locales, result should have no locales
+			a:   nil,
+			b:   []string{"en", "fr"},
+			exp: nil,
+		},
+		{
+			// if one of the entries has no locales, result should have no locales
+			a:   []string{"en"},
+			b:   nil,
+			exp: nil,
+		},
+	}
+	for _, test := range tests {
+		got := mergeLocales(test.a, test.b)
+		if !reflect.DeepEqual(got, test.exp) {
+			t.Fatalf("got %v, expected %v", got, test.exp)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/EverlongProject/i18n4go
 
-go 1.16
+go 1.23
 
 require (
 	github.com/EverlongProject/go-i18n v1.8.1


### PR DESCRIPTION
If you have two strings like this:

```
const A = "My Cool String" //locales:en,fr
const B = "My Cool String" //locales:es,it
```

We should be translating "My Cool String" to English, French, Spanish, and Italian. But we were only translating it to Spanish and Italian, because whichever string got parsed last won. Merge the results so we don't drop locales.